### PR TITLE
Update to email-styles.php to fix the iOS email app layout issue

### DIFF
--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -39,7 +39,12 @@ $base_lighter_40 = wc_hex_lighter( $base, 40 );
 $text_lighter_20 = wc_hex_lighter( $text, 20 );
 
 // !important; is a gmail hack to prevent styles being stripped if it doesn't like something.
+// body{padding: 0;} ensures proper scale/positioning of the email in the iOS native email app.
 ?>
+body {
+	padding: 0;
+}
+
 #wrapper {
 	background-color: <?php echo esc_attr( $bg ); ?>;
 	margin: 0;


### PR DESCRIPTION
Adding a style property to fix the iOS email app layout issue, described in #22308.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #22308.

### How to test the changes in this Pull Request:

1. Install Woocommerce.
2. Send any Woocommerce-styled email.
3. Open the email using the native iOS 12.1 email client.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added body {padding: 0;} CSS rule to the email-styles.php to fix the iOS emails layout issue.